### PR TITLE
Fix issue with untriggered wheels action on release

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -13,13 +13,13 @@ on:
     branches:
       - master
       - main
-    push:
-      branches:
-        - master
-        - main
-    release:
-      types:
-        - published
+  push:
+    branches:
+      - master
+      - main
+  release:
+    types:
+      - published
 
 concurrency:
   group: wheels-${{ github.head_ref }}


### PR DESCRIPTION
Improper indentation in the on: section of the workflow configuration was leading to releases not triggering the action. This should fix the issue.